### PR TITLE
docs: add docker-compose example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,24 +30,25 @@ Quickstart
 	docker run --device=/dev/vchiq --device=/dev/vcsm --volume=/opt/vc:/opt/vc --volume=/boot:/boot --volume=/sys:/dockerhost/sys:ro --volume=/etc:/dockerhost/etc:ro --volume=/proc:/dockerhost/proc:ro --volume=/usr/lib:/dockerhost/usr/lib:ro -p=8888:8888 --name="rpi-monitor" -d  michaelmiklis/rpi-monitor:latest
 
 **docker-compose**  
-
-
-	rpi-monitor:
-	  image: michaelmiklis/rpi-monitor:latest
-	  hostname: rpi-monitor
-	  restart: on-failure
-	  devices:
-	    - "/dev/vchiq:/dev/vchiq"
-	    - "/dev/vcsm:/dev/vcsm"
-	  volumes:
-	    - "/opt/vc:/opt/vc"
-	    - "/boot:/boot"
-	    - "/sys:/dockerhost/sys:ro"
-	    - "/etc:/dockerhost/etc:ro"
-	    - "/proc:/dockerhost/proc:ro"
-	    - "/usr/lib:/dockerhost/usr/lib:ro"
-	  ports:
-	    - "8888:8888"
+	
+	version: '3.6'
+	services:
+	  rpi-monitor:
+	    image: michaelmiklis/rpi-monitor:latest
+	    hostname: rpi-monitor
+	    restart: on-failure
+	    devices:
+	      - "/dev/vchiq:/dev/vchiq"
+	      - "/dev/vcsm:/dev/vcsm"
+	    volumes:
+	      - "/opt/vc:/opt/vc"
+	      - "/boot:/boot"
+	      - "/sys:/dockerhost/sys:ro"
+	      - "/etc:/dockerhost/etc:ro"
+	      - "/proc:/dockerhost/proc:ro"
+	      - "/usr/lib:/dockerhost/usr/lib:ro"
+	    ports:
+	      - "8888:8888"
 
 
 Access

--- a/README.md
+++ b/README.md
@@ -25,8 +25,31 @@ the Raspberry PI's vchiq and vcsm device needs to be mapped to the container to 
 
 Quickstart
 ----------
+**docker**  
+
 	docker run --device=/dev/vchiq --device=/dev/vcsm --volume=/opt/vc:/opt/vc --volume=/boot:/boot --volume=/sys:/dockerhost/sys:ro --volume=/etc:/dockerhost/etc:ro --volume=/proc:/dockerhost/proc:ro --volume=/usr/lib:/dockerhost/usr/lib:ro -p=8888:8888 --name="rpi-monitor" -d  michaelmiklis/rpi-monitor:latest
-	
+
+**docker-compose**  
+
+```
+  rpi-monitor:
+    image: michaelmiklis/rpi-monitor:latest
+    hostname: rpi-monitor
+    restart: on-failure
+    devices:
+      - "/dev/vchiq:/dev/vchiq"
+      - "/dev/vcsm:/dev/vcsm"
+    volumes:
+      - "/opt/vc:/opt/vc"
+      - "/boot:/boot"
+      - "/sys:/dockerhost/sys:ro"
+      - "/etc:/dockerhost/etc:ro"
+      - "/proc:/dockerhost/proc:ro"
+      - "/usr/lib:/dockerhost/usr/lib:ro"
+    ports:
+      - "8888:8888"
+```
+
 Access
 ----------
 After a successful start you can access the RPi-Monitor using http://dockerhost-ip:8888

--- a/README.md
+++ b/README.md
@@ -31,24 +31,24 @@ Quickstart
 
 **docker-compose**  
 
-```
-  rpi-monitor:
-    image: michaelmiklis/rpi-monitor:latest
-    hostname: rpi-monitor
-    restart: on-failure
-    devices:
-      - "/dev/vchiq:/dev/vchiq"
-      - "/dev/vcsm:/dev/vcsm"
-    volumes:
-      - "/opt/vc:/opt/vc"
-      - "/boot:/boot"
-      - "/sys:/dockerhost/sys:ro"
-      - "/etc:/dockerhost/etc:ro"
-      - "/proc:/dockerhost/proc:ro"
-      - "/usr/lib:/dockerhost/usr/lib:ro"
-    ports:
-      - "8888:8888"
-```
+
+	rpi-monitor:
+	  image: michaelmiklis/rpi-monitor:latest
+	  hostname: rpi-monitor
+	  restart: on-failure
+	  devices:
+	    - "/dev/vchiq:/dev/vchiq"
+	    - "/dev/vcsm:/dev/vcsm"
+	  volumes:
+	    - "/opt/vc:/opt/vc"
+	    - "/boot:/boot"
+	    - "/sys:/dockerhost/sys:ro"
+	    - "/etc:/dockerhost/etc:ro"
+	    - "/proc:/dockerhost/proc:ro"
+	    - "/usr/lib:/dockerhost/usr/lib:ro"
+	  ports:
+	    - "8888:8888"
+
 
 Access
 ----------


### PR DESCRIPTION
Hi! Thanks for this port :)

I've added a simple `docker-compose` example in the readme, thought it might be useful for others as well?